### PR TITLE
fix: figure 4

### DIFF
--- a/draft-ietf-drip-arch.md
+++ b/draft-ietf-drip-arch.md
@@ -375,14 +375,14 @@ as context, some entities and interfaces beyond the scope of DRIP (as currently 
 * +-----+     * Registration *          * Registration *     +-----+ *
 *             * (and UTM)    *          * (and UTM)    *             *
 ***************              ************              ***************
-                               |  |  |
-                +----------+   |  |  |   +----------+
-                | Public   o---'  |  '---o Private  |
-                | Registry |      |      | Registry |
-                +----------+      |      +----------+
-                               +--o--+
-                               | DNS |
-                               +-----+
+                               | |  | |
+        +------------------+   | |  | |   +-----------------------+
+        | Public/Private   o---' |  | '---o UTM Supplemental Data |
+        | Registry         |     |  |     | Service Provider      |
+        +------------------+     |  |     +-----------------------+
+                     +-----+     |  |     +---------+
+                     | DNS o-----'  '-----o UTM USS |
+                     +-----+              +---------+
 
 DAA:  Detect And Avoid
 GPOD: General Public Observer Device


### PR DESCRIPTION
Attempt to fix Roman's point on not having CS-RID as part of figure. 

While CS-RID is not specifically called out by name here its base form of an Supplemental Data Service Provider (SDSP) in UTM is.

This also closes a bit of a loop hole in that UTM was not explicitly represented in the figure - which may be desired.